### PR TITLE
Schema versions

### DIFF
--- a/src/Libraries.Core/Decoupling/AnonymousSchema.cs
+++ b/src/Libraries.Core/Decoupling/AnonymousSchema.cs
@@ -1,0 +1,9 @@
+﻿namespace Nexus.Link.Libraries.Core.Decoupling
+{
+    /// <inheritdoc />
+    public class AnonymousSchema : IVersionedSchema
+    {
+        /// <inheritdoc />
+        public int? SchemaVersion { get; set; }
+    }
+}

--- a/src/Libraries.Core/Decoupling/INamedSchema.cs
+++ b/src/Libraries.Core/Decoupling/INamedSchema.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nexus.Link.Libraries.Core.Decoupling
+{
+    /// <summary>
+    /// This interface is typically used when more than one type of data is stored at the same place and therefore the type of data needs to be stored together with the data.
+    /// By first reading the data into a <see cref="T:Nexus.Link.Libraries.Core.Decoupling.NamedSchema" />, the type and version can be determined and the data can be read into
+    /// the correct type with the correct version of that type.
+    /// </summary>
+    /// <inheritdoc />
+    public interface INamedSchema : IVersionedSchema
+    {
+        /// <summary>
+        /// The name of the schema for the data.
+        /// </summary>
+        string SchemaName { get; }
+    }
+}

--- a/src/Libraries.Core/Decoupling/IVersionedSchema.cs
+++ b/src/Libraries.Core/Decoupling/IVersionedSchema.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nexus.Link.Libraries.Core.Decoupling
+{
+    /// <summary>
+    /// This interface is typically used for data that needs to be stored with different versions of the schema that is stored.
+    /// By first reading the data into a <see cref="AnonymousSchema"/>, the version can be determined and the data can be read into
+    /// a type that supports the version.
+    /// </summary>
+    public interface IVersionedSchema
+    {
+        /// <summary>
+        /// The version of a schema
+        /// </summary>
+        int? SchemaVersion { get; }
+    }
+}

--- a/src/Libraries.Core/Decoupling/NamedSchema.cs
+++ b/src/Libraries.Core/Decoupling/NamedSchema.cs
@@ -1,0 +1,12 @@
+﻿namespace Nexus.Link.Libraries.Core.Decoupling
+{
+    /// <inheritdoc />
+    public class NamedSchema : INamedSchema
+    {
+        /// <inheritdoc />
+        public int? SchemaVersion { get; set; }
+
+        /// <inheritdoc />
+        public string SchemaName { get; set; }
+    }
+}

--- a/src/Libraries.Core/Decoupling/NamedSchema.cs
+++ b/src/Libraries.Core/Decoupling/NamedSchema.cs
@@ -1,11 +1,8 @@
 ﻿namespace Nexus.Link.Libraries.Core.Decoupling
 {
-    /// <inheritdoc />
-    public class NamedSchema : INamedSchema
+    /// <inheritdoc cref="INamedSchema" />
+    public class NamedSchema : AnonymousSchema, INamedSchema
     {
-        /// <inheritdoc />
-        public int? SchemaVersion { get; set; }
-
         /// <inheritdoc />
         public string SchemaName { get; set; }
     }

--- a/src/Libraries.Core/Decoupling/SchemaParser.cs
+++ b/src/Libraries.Core/Decoupling/SchemaParser.cs
@@ -73,7 +73,7 @@ namespace Nexus.Link.Libraries.Core.Decoupling
         /// <param name="json">The JSON string to convert.</param>
         /// <param name="obj">The converted object.</param>
         /// <returns>True if the conversion was successful.</returns>
-        public bool TryConvert(string json, out object obj)
+        public bool TryParse(string json, out object obj)
         {
             var isSuccess = TryParse(json, out _, out _, out var o);
             obj = o;

--- a/src/Libraries.Core/Decoupling/SchemaParser.cs
+++ b/src/Libraries.Core/Decoupling/SchemaParser.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Nexus.Link.Libraries.Core.Assert;
+
+namespace Nexus.Link.Libraries.Core.Decoupling
+{
+    public class SchemaParser
+    {
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<int, Type>> _typeDictionary =
+            new ConcurrentDictionary<string, ConcurrentDictionary<int, Type>>();
+
+        /// <summary>
+        /// Register a <paramref name="type"/> for an anonymous schema name and an unspecified schema version.
+        /// </summary>
+        /// <remarks>Same as registering the schema name "" and schema version 0.</remarks>
+        public SchemaParser Add(Type type)
+        {
+            InternalContract.RequireNotNull(type, nameof(type));
+            return Add("", 0, type);
+        }
+
+        /// <summary>
+        /// Register a <paramref name="type"/> for an anonymous schema name and a specific <paramref name="schemaVersion"/>.
+        /// </summary>
+        /// <remarks>Same as registering the schema name "".</remarks>
+        public SchemaParser Add(int schemaVersion, Type type)
+        {
+            InternalContract.RequireGreaterThanOrEqualTo(0, schemaVersion, nameof(schemaVersion));
+            InternalContract.RequireNotNull(type, nameof(type));
+            return Add("", schemaVersion, type);
+        }
+
+        /// <summary>
+        /// Register a <paramref name="type"/> for a specific <paramref name="schemaName"/> and <paramref name="schemaVersion"/>.
+        /// </summary>
+        public SchemaParser Add(string schemaName, int schemaVersion, Type type)
+        {
+            InternalContract.RequireNotNull(schemaName, nameof(schemaName));
+            InternalContract.RequireGreaterThanOrEqualTo(0, schemaVersion, nameof(schemaVersion));
+            InternalContract.RequireNotNull(type, nameof(type));
+            if (!_typeDictionary.TryGetValue(schemaName, out var versionDictionary))
+            {
+                versionDictionary = new ConcurrentDictionary<int, Type>();
+                if (!_typeDictionary.TryAdd(schemaName, versionDictionary))
+                {
+                    versionDictionary = _typeDictionary[schemaName];
+                }
+            }
+
+            var success = versionDictionary.TryAdd(schemaVersion, type);
+            InternalContract.Require(success, $"Schema {schemaName} version {schemaVersion} had already been added.");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Get the registered type for a specific <paramref name="schemaName"/> and <paramref name="schemaVersion"/>.
+        /// </summary>
+        private Type Get(string schemaName, int schemaVersion)
+        {
+            InternalContract.RequireNotNull(schemaName, nameof(schemaName));
+            InternalContract.RequireGreaterThanOrEqualTo(0, schemaVersion, nameof(schemaVersion));
+            if (!_typeDictionary.TryGetValue(schemaName, out var versionDictionary)) return null;
+            return versionDictionary.TryGetValue(schemaVersion, out var type) ? type : null;
+        }
+
+        /// <summary>
+        /// Try to convert a JSON string into an object of one of the registered types
+        /// </summary>
+        /// <param name="json">The JSON string to convert.</param>
+        /// <param name="obj">The converted object.</param>
+        /// <returns>True if the conversion was successful.</returns>
+        public bool TryConvert(string json, out object obj)
+        {
+            var isSuccess = TryParse(json, out _, out _, out var o);
+            obj = o;
+            return isSuccess;
+        }
+
+        /// <summary>
+        /// Try to convert a JSON string into an object of one of the registered types
+        /// </summary>
+        /// <param name="json">The JSON string to convert.</param>
+        /// <param name="schemaName">The schema name that was used for the conversion.</param>
+        /// <param name="schemaVersion">The schema version that was used for the conversion.</param>
+        /// <param name="obj">The converted object.</param>
+        /// <returns>True if the conversion was successful.</returns>
+        public bool TryParse(string json, out string schemaName, out int schemaVersion, out object obj)
+        {
+            schemaName = null;
+            schemaVersion = 0;
+            obj = null;
+            if (json == null) return false;
+            var probe = JsonConvert.DeserializeObject<NamedSchema>(json);
+            if (probe == null) return false;
+            schemaName = probe.SchemaName ?? "";
+            schemaVersion = probe.SchemaVersion ?? 0;
+            var type = Get(schemaName, schemaVersion);
+            if (type == null) return false;
+            obj = JsonConvert.DeserializeObject(json, type);
+            return true;
+        }
+    }
+}

--- a/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestAnonymousSchema.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestAnonymousSchema.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Nexus.Link.Libraries.Core.Decoupling;
+using UT = Microsoft.VisualStudio.TestTools.UnitTesting;
+#pragma warning disable 659
+
+namespace Nexus.Link.Libraries.Core.Tests.Decoupling
+{
+    [TestClass]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Local")]
+    public class TestAnonymousSchema
+    {
+        [TestMethod]
+        public void SchemaNotVersioned()
+        {
+            var dataBefore = new DataNoVersion { Zero = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var probe = JsonConvert.DeserializeObject<AnonymousSchema>(json);
+            UT.Assert.IsNotNull(probe);
+            UT.Assert.IsNull(probe.SchemaVersion);
+        }
+
+        [TestMethod]
+        public void SchemaVersioned()
+        {
+            var dataBefore = new DataVersion1 { First = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var probe = JsonConvert.DeserializeObject<AnonymousSchema>(json);
+            UT.Assert.IsNotNull(probe);
+            UT.Assert.IsNotNull(probe.SchemaVersion);
+            UT.Assert.AreEqual(dataBefore.SchemaVersion, probe.SchemaVersion);
+        }
+
+        [TestMethod]
+        public void DeserializationBasedOnSchemaVersion()
+        {
+            var dataOfDifferentVersions = new List<object>()
+            {
+                new DataNoVersion { Zero = Guid.NewGuid().ToString() },
+                new DataVersion1 { First = Guid.NewGuid().ToString() },
+                new DataVersion2 { Second = Guid.NewGuid().ToString() }
+            };
+            foreach (var dataBefore in dataOfDifferentVersions)
+            {
+                var json = JsonConvert.SerializeObject(dataBefore);
+                var probe = JsonConvert.DeserializeObject<AnonymousSchema>(json);
+                UT.Assert.IsNotNull(probe);
+                if (!probe.SchemaVersion.HasValue)
+                {
+                    var dataAfter = JsonConvert.DeserializeObject<DataNoVersion>(json);
+                    UT.Assert.AreEqual(dataBefore, dataAfter);
+                }
+                else
+                {
+                    switch (probe.SchemaVersion.Value)
+                    {
+                        case 1:
+                            var dataAfter1 = JsonConvert.DeserializeObject<DataVersion1>(json);
+                            UT.Assert.AreEqual(dataBefore, dataAfter1);
+                            break;
+                        case 2:
+                            var dataAfter2 = JsonConvert.DeserializeObject<DataVersion2>(json);
+                            UT.Assert.AreEqual(dataBefore, dataAfter2);
+                            break;
+                        default:
+                            UT.Assert.Fail($"Unknown schema version: {probe.SchemaVersion.Value}");
+                            break;
+                    }
+                }
+            }
+        }
+
+
+        private class DataNoVersion
+        {
+            public string Zero { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataNoVersion data)) return false;
+                return data.Zero == Zero;
+            }
+        }
+
+        private class DataVersion1 : IVersionedSchema
+        {
+            public int? SchemaVersion { get; } = 1;
+            public string First { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataVersion1 data)) return false;
+                return data.First == First;
+            }
+        }
+
+        private class DataVersion2 : IVersionedSchema
+        {
+            public int? SchemaVersion { get; } = 2;
+            public string Second { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataVersion2 data)) return false;
+                return data.Second == Second;
+            }
+        }
+    }
+}

--- a/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestNamedSchema.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestNamedSchema.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Nexus.Link.Libraries.Core.Decoupling;
+using UT = Microsoft.VisualStudio.TestTools.UnitTesting;
+#pragma warning disable 659
+
+namespace Nexus.Link.Libraries.Core.Tests.Decoupling
+{
+    [TestClass]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Local")]
+    public class TestNamedSchema
+    {
+        [TestMethod]
+        public void SchemaNoName()
+        {
+            var dataBefore = new DataAnonymous { Zero = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var probe = JsonConvert.DeserializeObject<NamedSchema>(json);
+            UT.Assert.IsNotNull(probe);
+            UT.Assert.IsNull(probe.SchemaName);
+            UT.Assert.IsNull(probe.SchemaVersion);
+        }
+
+        [TestMethod]
+        public void SchemaVersioned()
+        {
+            var dataBefore = new DataType1Version1 { First = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var probe = JsonConvert.DeserializeObject<NamedSchema>(json);
+            UT.Assert.IsNotNull(probe);
+            UT.Assert.IsNotNull(probe.SchemaVersion);
+            UT.Assert.AreEqual(dataBefore.SchemaName, probe.SchemaName);
+            UT.Assert.AreEqual(dataBefore.SchemaVersion, probe.SchemaVersion);
+        }
+
+        [TestMethod]
+        public void DeserializationBasedOnSchemaVersion()
+        {
+            var dataOfDifferentVersions = new List<object>()
+            {
+                new DataAnonymous { Zero = Guid.NewGuid().ToString() },
+                new DataType1Version1 { First = Guid.NewGuid().ToString() },
+                new DataType2Version2 { Second = Guid.NewGuid().ToString() }
+            };
+            foreach (var dataBefore in dataOfDifferentVersions)
+            {
+                var json = JsonConvert.SerializeObject(dataBefore);
+                var probe = JsonConvert.DeserializeObject<NamedSchema>(json);
+                UT.Assert.IsNotNull(probe);
+                if (probe.SchemaName == null)
+                {
+                    var dataAfter = JsonConvert.DeserializeObject<DataAnonymous>(json);
+                    UT.Assert.AreEqual(dataBefore, dataAfter);
+                }
+                else
+                {
+                    switch (probe.SchemaName)
+                    {
+                        case "DataType1":
+                            var dataAfter1 = JsonConvert.DeserializeObject<DataType1Version1>(json);
+                            UT.Assert.AreEqual(dataBefore, dataAfter1);
+                            break;
+                        case "DataType2":
+                            var dataAfter2 = JsonConvert.DeserializeObject<DataType2Version2>(json);
+                            UT.Assert.AreEqual(dataBefore, dataAfter2);
+                            break;
+                        default:
+                            UT.Assert.Fail($"Unknown schema name: {probe.SchemaName}");
+                            break;
+                    }
+                }
+            }
+        }
+
+
+        private class DataAnonymous
+        {
+            public string Zero { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataAnonymous data)) return false;
+                return data.Zero == Zero;
+            }
+        }
+
+        private class DataType1Version1 : INamedSchema
+        {
+            public string SchemaName { get; } = "DataType1";
+            public int? SchemaVersion { get; } = 1;
+            public string First { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataType1Version1 data)) return false;
+                return data.First == First;
+            }
+        }
+
+        private class DataType2Version2 : INamedSchema
+        {
+            public string SchemaName { get; } = "DataType2";
+            public int? SchemaVersion { get; } = 2;
+            public string Second { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataType2Version2 data)) return false;
+                return data.Second == Second;
+            }
+        }
+    }
+}

--- a/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestSchemaParser.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestSchemaParser.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Nexus.Link.Libraries.Core.Application;
+using Nexus.Link.Libraries.Core.Decoupling;
+using Nexus.Link.Libraries.Core.Error.Logic;
+using Nexus.Link.Libraries.Core.Tests.Queue;
+using UT = Microsoft.VisualStudio.TestTools.UnitTesting;
+#pragma warning disable 659
+
+namespace Nexus.Link.Libraries.Core.Tests.Decoupling
+{
+    [TestClass]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Local")]
+    public class TestSchemaParser
+    {
+        [TestInitialize]
+        public void RunBeforeEachTestMethod()
+        {
+            FulcrumApplicationHelper.UnitTestSetup(typeof(TestSchemaParser).FullName);
+        }
+
+        [TestMethod]
+        public void ParseTypes()
+        {
+            var schemaParser = new SchemaParser()
+                .Add(typeof(DataAnonymous))
+                .Add("DataType1", 1, typeof(DataType1Version1))
+                .Add("DataType2", 1, typeof(DataType2Version1))
+                .Add("DataType2", 2, typeof(DataType2Version2));
+            var dataOfDifferentVersions = new List<object>()
+            {
+                new DataAnonymous {Zero = Guid.NewGuid().ToString()},
+                new DataType1Version1 {First = Guid.NewGuid().ToString()},
+                new DataType2Version1 {Second = Guid.NewGuid().ToString()},
+                new DataType2Version2 {Third = Guid.NewGuid().ToString()}
+            };
+            foreach (var dataBefore in dataOfDifferentVersions)
+            {
+                var json = JsonConvert.SerializeObject(dataBefore);
+                var success = schemaParser.TryParse(json, out _, out _, out var dataAfter);
+                UT.Assert.IsTrue(success);
+                UT.Assert.AreEqual(dataBefore, dataAfter);
+            }
+        }
+
+        [TestMethod]
+        public void UnknownType()
+        {
+            var schemaParser = new SchemaParser()
+                .Add("DataType1", 1, typeof(DataType1Version1));
+            var dataBefore = new DataType2Version2 { Third = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var success = schemaParser.TryParse(json, out var schemaName, out var schemaVersion, out _);
+            UT.Assert.IsFalse(success);
+            UT.Assert.AreEqual("DataType2", schemaName);
+            UT.Assert.AreEqual(2, schemaVersion);
+        }
+
+        [TestMethod]
+        public void UnknownVersion()
+        {
+            var schemaParser = new SchemaParser()
+                .Add("DataType2", 1, typeof(DataType2Version1));
+            var dataBefore = new DataType2Version2 { Third = Guid.NewGuid().ToString() };
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var success = schemaParser.TryParse(json, out var schemaName, out var schemaVersion, out _);
+            UT.Assert.IsFalse(success);
+            UT.Assert.AreEqual("DataType2", schemaName);
+            UT.Assert.AreEqual(2, schemaVersion);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FulcrumContractException))]
+        public void NegativeVersion()
+        {
+            new SchemaParser().Add(-1, typeof(DataAnonymous));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FulcrumContractException))]
+        public void NullName()
+        {
+            new SchemaParser().Add(null, 1, typeof(DataAnonymous));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FulcrumContractException))]
+        public void NullType()
+        {
+            new SchemaParser().Add("Test", 1, null);
+        }
+
+
+        private class DataAnonymous
+        {
+            public string Zero { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataAnonymous data)) return false;
+                return data.Zero == Zero;
+            }
+        }
+
+        private class DataType1Version1 : INamedSchema
+        {
+            public string SchemaName { get; } = "DataType1";
+            public int? SchemaVersion { get; } = 1;
+            public string First { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataType1Version1 data)) return false;
+                return data.First == First;
+            }
+        }
+
+        private class DataType2Version1 : INamedSchema
+        {
+            public string SchemaName { get; } = "DataType2";
+            public int? SchemaVersion { get; } = 1;
+            public string Second { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataType2Version1 data)) return false;
+                return data.Second == Second;
+            }
+        }
+
+        private class DataType2Version2 : INamedSchema
+        {
+            public string SchemaName { get; } = "DataType2";
+            public int? SchemaVersion { get; } = 2;
+            public string Third { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is DataType2Version2 data)) return false;
+                return data.Third == Third;
+            }
+        }
+    }
+}

--- a/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestSchemaParser.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Decoupling/TestSchemaParser.cs
@@ -23,6 +23,18 @@ namespace Nexus.Link.Libraries.Core.Tests.Decoupling
         }
 
         [TestMethod]
+        public void ParseAnonymous()
+        {
+            var schemaParser = new SchemaParser()
+                .Add(typeof(DataAnonymous));
+            var dataBefore = new DataAnonymous {Zero = Guid.NewGuid().ToString()};
+            var json = JsonConvert.SerializeObject(dataBefore);
+            var success = schemaParser.TryParse(json, out var dataAfter);
+            UT.Assert.IsTrue(success);
+            UT.Assert.AreEqual(dataBefore, dataAfter);
+        }
+
+        [TestMethod]
         public void ParseTypes()
         {
             var schemaParser = new SchemaParser()

--- a/test/Nexus.Link.Libraries.Core.Tests/Translate/TestConceptValue.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Translate/TestConceptValue.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UT = Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Nexus.Link.Libraries.Core.Tests.TestDecoupling
+namespace Nexus.Link.Libraries.Core.Tests.Translate
 {
     [TestClass]
     public class TestConceptValue


### PR DESCRIPTION
Added functionality for having schema names and versions. See [documentation](https://github.com/nexus-link/Nexus.Link.Libraries/blob/master/src/Libraries.Web/README.md).
There are [tests](https://github.com/nexus-link/Nexus.Link.Libraries/tree/feature/schema-version/test/Nexus.Link.Libraries.Core.Tests/Decoupling) that shows how the functionality can be used.
 