### PR TITLE
Slow serialization

### DIFF
--- a/src/Libraries.Web/RestClientHelper/RestClient.cs
+++ b/src/Libraries.Web/RestClientHelper/RestClient.cs
@@ -365,9 +365,7 @@ namespace Nexus.Link.Libraries.Web.RestClientHelper
                 if (responseContent == null) return result;
                 try
                 {
-                    result.Body =
-                        Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<TResponse>(responseContent,
-                            DeserializationSettings);
+                    result.Body = JsonConvert.DeserializeObject<TResponse>(responseContent, DeserializationSettings);
                 }
                 catch (Exception e)
                 {
@@ -420,8 +418,7 @@ namespace Nexus.Link.Libraries.Web.RestClientHelper
 
             if (instance != null)
             {
-                var requestContent =
-                    Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(instance, SerializationSettings);
+                var requestContent = JsonConvert.SerializeObject(instance, SerializationSettings);
                 request.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
                 request.Content.Headers.ContentType =
                     System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");


### PR DESCRIPTION
Då och då får vi prestandaproblem i våra restanrop via RestClient. Av någon anledning har vi inte använt Newtonsoft för serialisering/deserialisering i vår RestClient och Microsofts egen är långsammare. Denna pull request består i att byta ut Microsofts metoder till Newtonsofts.