### PR TITLE
Core 4.20.1: Fixed FulcrumApplication bootstrap problem where when we…

### DIFF
--- a/src/Libraries.Core/Assert/GenericBase.cs
+++ b/src/Libraries.Core/Assert/GenericBase.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using Nexus.Link.Libraries.Core.Application;
 using Nexus.Link.Libraries.Core.Error.Logic;
 using Nexus.Link.Libraries.Core.Logging;
 using Nexus.Link.Libraries.Core.Misc;
 
 namespace Nexus.Link.Libraries.Core.Assert
-{ 
+{
     /// <summary>
     /// A generic class for asserting things that the programmer thinks is true. Generic in the meaning that a parameter says what exception that should be thrown when an assumption is false.
     /// </summary>
@@ -26,7 +27,14 @@ namespace Nexus.Link.Libraries.Core.Assert
                 }
 
                 logMessage += ".";
-                Log.LogError(logMessage, exception);
+
+                // Special case when there is something wrong in the ApplicationSetup, we do not log,
+                // because that would trigger a validation of the ApplicationSetup,
+                // which hasn't had a chance to set the properties.
+                if (FulcrumApplication.Setup.SynchronousFastLogger != null)
+                {
+                    Log.LogError(logMessage, exception);
+                }
             }
             throw exception;
         }

--- a/src/Libraries.Core/Libraries.Core.csproj
+++ b/src/Libraries.Core/Libraries.Core.csproj
@@ -33,16 +33,17 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Core</PackageId>
-    <Version>4.20.0</Version>
+    <Version>4.20.1</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
     <PackageProjectUrl>https://github.com/nexus-link/Nexus.Link.Libraries</PackageProjectUrl>
     <PackageLanguage>en-US</PackageLanguage>
     <Description>Nexus core library based on .NET Standard</Description>
-    <Copyright>Copyright ©2020 Xlent Link AB</Copyright>
+    <Copyright>Copyright ©2021 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      4.20.1 Fixed FulcrumApplication bootstrap problem where when we logged an error about e.g. RunTimeLevel.None, we required all properties of ApplicationSetup being setup, but the logging happened before we could set them
       4.20.0 MemoryQueue now has a separate set method for item actions.
       4.19.1 Fix: ITranslatorService is not called on return in in-pipe if no translations are present
       4.19.0 Added setters on Tenant (for deserialization)

--- a/test/Nexus.Link.Libraries.Core.Tests/Application/BootstrapApplicationTests.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Application/BootstrapApplicationTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Nexus.Link.Libraries.Core.Application;
+using Nexus.Link.Libraries.Core.Assert;
+using Nexus.Link.Libraries.Core.Logging;
+using Nexus.Link.Libraries.Core.MultiTenant.Model;
+using UT = Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Nexus.Link.Libraries.Core.Tests.Application
+{
+    [TestClass]
+    public class BootstrapApplicationTests
+    {
+        [TestMethod]
+        public void RunTimeLevel_Cant_Be_None()
+        {
+            try
+            {
+                // Before bug fix 4.20.1 this would through exception due to Log.LogError doing validation on ApplicationSetup,
+                // which had no chance of setting the ApplicationSetup properties because the logging intervened
+                FulcrumApplicationHelper.RuntimeSetup("app-name", new Tenant("o", "e"), RunTimeLevelEnum.None);
+                UT.Assert.Fail("Expected exception");
+            }
+            catch (Exception e)
+            {
+                UT.Assert.IsTrue(e.Message.Contains(nameof(RunTimeLevelEnum.None)),
+                    $"Expected error message to contain {nameof(RunTimeLevelEnum.None)}, but it didn't. Was {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// The 4.20.1 fix changed GenericBase. Make sure it can still LogError when it's supposed to.
+        /// </summary>
+        [TestMethod]
+        public void GenericBase_Can_Still_Log_Error()
+        {
+            FulcrumApplicationHelper.UnitTestSetup(nameof(BootstrapApplicationTests));
+
+            var loggerMock = new Mock<ISyncLogger>();
+            FulcrumApplication.Setup.SynchronousFastLogger = loggerMock.Object;
+
+            LogRecord loggedRecord = null;
+            loggerMock
+                .Setup(x => x.LogSync(It.IsAny<LogRecord>()))
+                .Callback((LogRecord logRecord) =>
+                {
+                    loggedRecord = logRecord;
+                    Console.WriteLine("LOGGED MESSAGE: " + logRecord.ToLogString());
+                });
+
+            try
+            {
+                FulcrumAssert.IsNotNull(null, "NIL");
+                UT.Assert.Fail("Expected exception");
+            }
+            catch (Exception)
+            {
+                UT.Assert.IsNotNull(loggedRecord, "Expected a log record");
+                UT.Assert.AreEqual(LogSeverityLevel.Error, loggedRecord.SeverityLevel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
… logged an error about e.g. RunTimeLevel.None, we required all properties of ApplicationSetup being setup, but the logging happened before we could set them