### PR TITLE
Fixes/nuget update/larsl

### DIFF
--- a/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
+++ b/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
   </ItemGroup>
 

--- a/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
+++ b/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
@@ -28,7 +28,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Azure</PackageId>
-    <Version>3.7.4</Version>
+    <Version>3.7.5</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -38,6 +38,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      3.7.5 Updated nugets to avoid versions with security risks
       3.7.4 Now throws FulcrumResourceLockedException instead of FulcrumTryAgainException if a resource is locked
       3.7.3 Bump
       3.7.1 Improve performance of blob create and return

--- a/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
+++ b/src/Libraries.Azure.Storage/Libraries.Azure.Storage.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
   </ItemGroup>

--- a/src/Libraries.Azure.Web.AspNet/Libraries.Azure.Web.AspNet.csproj
+++ b/src/Libraries.Azure.Web.AspNet/Libraries.Azure.Web.AspNet.csproj
@@ -41,7 +41,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Azure.Web.AspNet</PackageId>
-    <Version>1.4.8</Version>
+    <Version>1.4.9</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -51,7 +51,7 @@
     <Copyright>Copyright ©2020 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
-      1.4.8 Bump
+      1.4.9 Bump
       1.4.4 Symbols
       1.4.3 Bump
       1.4.1 Old obsolete stuff with errors has been deleted and old with warning has been updated to error.

--- a/src/Libraries.Azure.Web.AspNet/Libraries.Azure.Web.AspNet.csproj
+++ b/src/Libraries.Azure.Web.AspNet/Libraries.Azure.Web.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
@@ -26,10 +27,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.10.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.10.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.10.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
 
   </ItemGroup>
 

--- a/src/Libraries.Core/Libraries.Core.csproj
+++ b/src/Libraries.Core/Libraries.Core.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />

--- a/src/Libraries.Core/Libraries.Core.csproj
+++ b/src/Libraries.Core/Libraries.Core.csproj
@@ -51,7 +51,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Core</PackageId>
-    <Version>5.26.0</Version>
+    <Version>5.26.1</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -61,6 +61,7 @@
     <Copyright>Copyright ©2021 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      5.26.1 Updated nugets to avoid versions with security risks
       5.26.0 FulcrumException and FulcrumError now understands Exception.Data. This is important for the new Fulcrum Exceptions; FulcrumRedirectException and FulcrumHttpRedirectException
       5.25.1 Moved EntityAttributes classes from Crud to here
       5.25.0 Added Hint.Nullable. Better path for validation. Validation assertions didn't use codeLocation properly

--- a/src/Libraries.Core/Libraries.Core.csproj
+++ b/src/Libraries.Core/Libraries.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />

--- a/src/Libraries.Crud.AspNet/Libraries.Crud.AspNet.csproj
+++ b/src/Libraries.Crud.AspNet/Libraries.Crud.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <RootNamespace>Nexus.Link.Libraries.Crud.AspNet</RootNamespace>
     <AssemblyName>Nexus.Link.Libraries.Crud.AspNet</AssemblyName>
 
@@ -17,13 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <ProjectReference Include="..\Libraries.Crud.Web\Libraries.Crud.Web.csproj" />
     <ProjectReference Include="..\Libraries.Web.AspNet\Libraries.Web.AspNet.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1, 3.0)" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.2.0, 3.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Libraries.Crud.AspNet/Libraries.Crud.AspNet.csproj
+++ b/src/Libraries.Crud.AspNet/Libraries.Crud.AspNet.csproj
@@ -28,7 +28,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Crud.AspNet</PackageId>
-    <Version>2.7.7</Version>
+    <Version>2.7.8</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -38,7 +38,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
-      2.7.7 Bump
+      2.7.8 Bump
       2.7.2 Added ICreateChild and ICreateChildAndReturn
       2.6.3 Symbols
       2.6.2 Bump

--- a/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
+++ b/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
+++ b/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
+++ b/src/Libraries.Crud.UnitTests/Libraries.Crud.UnitTests.csproj
@@ -30,7 +30,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Crud.UnitTests</PackageId>
-    <Version>1.4.4</Version>
+    <Version>1.4.5</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -40,6 +40,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      1.4.5 Bump
       1.4.4 Now should throw FulcrumResourceLockedException instead of FulcrumTryAgainException if a resource is locked
       1.4.3 Bump
       1.4.0 Support for entity attributes such as PrimaryKeyAttribute

--- a/src/Libraries.Crud.UnitTests/ManyToOne/TestIManyToOneBase.cs
+++ b/src/Libraries.Crud.UnitTests/ManyToOne/TestIManyToOneBase.cs
@@ -42,7 +42,7 @@ namespace Nexus.Link.Libraries.Crud.UnitTests.ManyToOne
             item.InitializeWithDataForTesting(type);
             item.ParentId = parentId;
             var createdItem = await storage.CreateAndReturnAsync(item, cancellationToken);
-            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(default(TId), createdItem);
+            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(default(TId), createdItem.Id);
             return createdItem;
         }
 
@@ -51,7 +51,7 @@ namespace Nexus.Link.Libraries.Crud.UnitTests.ManyToOne
             var item = new TestItemId<TId>();
             item.InitializeWithDataForTesting(type);
             var createdItem = await OneStorage.CreateAndReturnAsync(item, cancellationToken);
-            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(default(TId), createdItem);
+            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(default(TId), createdItem.Id);
             return createdItem;
         }
     }

--- a/src/Libraries.Crud.Web/Libraries.Crud.Web.csproj
+++ b/src/Libraries.Crud.Web/Libraries.Crud.Web.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.20" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>

--- a/src/Libraries.Crud.Web/Libraries.Crud.Web.csproj
+++ b/src/Libraries.Crud.Web/Libraries.Crud.Web.csproj
@@ -35,7 +35,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Crud.Web</PackageId>
-    <Version>2.12.0</Version>
+    <Version>2.12.1</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -45,6 +45,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      2.12.1 Bump
       2.12.0 Remvoed the FileSystem code again. First to meta-model. Later to SDK
       2.11.1 Made AzureDevopsGit services public
       2.11.0 Added FileSystem

--- a/src/Libraries.Crud/Libraries.Crud.csproj
+++ b/src/Libraries.Crud/Libraries.Crud.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Crud</PackageId>
-    <Version>3.15.1</Version>
+    <Version>3.15.2</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -34,6 +34,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      3.15.2 Bump
       3.15.1 Removed Hint again
       3.15.0 Added Hint for crud methods
       3.14.2 Removed FileSystem. It became obsolete once we implemented IFileSystem

--- a/src/Libraries.Crud/Libraries.Crud.csproj
+++ b/src/Libraries.Crud/Libraries.Crud.csproj
@@ -13,7 +13,7 @@
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.2" />
     <PackageReference Include="System.IO.Abstractions" Version="17.1.1" />
   </ItemGroup>

--- a/src/Libraries.SqlServer/Libraries.SqlServer.csproj
+++ b/src/Libraries.SqlServer/Libraries.SqlServer.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
   </ItemGroup>

--- a/src/Libraries.SqlServer/Libraries.SqlServer.csproj
+++ b/src/Libraries.SqlServer/Libraries.SqlServer.csproj
@@ -29,7 +29,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.SqlServer</PackageId>
-    <Version>2.15.5</Version>
+    <Version>2.15.6</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -39,6 +39,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      2.15.6 Bump
       2.15.5 InternalQueryAsync now calls MaybeTransformEtagToRecordVersion
       2.15.4 Now throws FulcrumResourceLockedException instead of FulcrumTryAgainException if a resource is locked
       2.15.3 Bump

--- a/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
+++ b/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -15,25 +15,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="System.Web"></Reference>
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.9" />
     <PackageReference Include="Swashbuckle.Core" Version="5.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="[2.1.1,3.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.1.1,3.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1, 3.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="[2.1.1,3.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="4.0.1" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
+++ b/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
@@ -43,7 +43,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Web.AspNet</PackageId>
-    <Version>3.4.1</Version>
+    <Version>3.4.2</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -53,6 +53,7 @@
     <Copyright>Copyright ©2019 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      3.4.2 Bump
       3.4.1 Fixed an issue where we tried to set information on response after beginning to write response content.
       3.4.0 Added AspNetExceptionConverter.ConvertExceptionToCustomHttpResponse()
       3.3.0 ConvertExceptionToResponse now can convert FulcrumHttpRedirectException to HTTP response. Made AspNetExceptionConverter.ToContentResult() obsolete, replaced by ConvertExceptionToResponseAsync()

--- a/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
+++ b/src/Libraries.Web.AspNet/Libraries.Web.AspNet.csproj
@@ -12,12 +12,10 @@
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
     <IncludeSymbols>true</IncludeSymbols>
+    <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Libraries.Web.AspNet/Startup/RemoveRedundantControllers.cs
+++ b/src/Libraries.Web.AspNet/Startup/RemoveRedundantControllers.cs
@@ -1,6 +1,5 @@
-﻿
+﻿#if NETCOREAPP
 using System.Reflection;
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Libraries.Web.AspNet/Startup/StartupBase.cs
+++ b/src/Libraries.Web.AspNet/Startup/StartupBase.cs
@@ -1,8 +1,8 @@
-﻿
+﻿#if NETCOREAPP
+using Microsoft.OpenApi.Models;
 using Nexus.Link.Libraries.Core.Misc;
 using Nexus.Link.Libraries.Core.Platform.Services;
 using Nexus.Link.Libraries.Web.AspNet.Pipe;
-#if NETCOREAPP
 using System;
 using System.Reflection;
 using System.Collections.Generic;
@@ -148,7 +148,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
                     var service = serviceProvider.GetService(serviceType);
                     if (service == null) continue;
                     var controllerTypes = _capabilityInterfaceToControllerClasses[serviceType];
-                    FulcrumAssert.IsNotNull(controllerTypes);        
+                    FulcrumAssert.IsNotNull(controllerTypes);
                     var controllerList = controllerTypes as List<Type> ?? controllerTypes.ToList();
 
                     foreach (var controllerType in controllerList)
@@ -184,7 +184,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
         public void RegisterControllersForCapability<TControllerInjector>(params Type[] controllerTypes)
             where TControllerInjector : IControllerInjector
         {
-            InternalContract.Require(typeof(TControllerInjector).IsInterface, 
+            InternalContract.Require(typeof(TControllerInjector).IsInterface,
                 $"The type ({typeof(TControllerInjector).Name}) passed to {nameof(RegisterControllersForCapability)} must be an interface.");
             RegisterControllersForCapability(typeof(TControllerInjector), controllerTypes);
         }
@@ -195,9 +195,9 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
         public void RegisterControllersForCapability(Type capabilityInterface, params Type[] controllerTypes)
         {
             InternalContract.Require(capabilityInterface, type => type.IsInterface, nameof(capabilityInterface));
-            InternalContract.Require(capabilityInterface.IsInterface, 
+            InternalContract.Require(capabilityInterface.IsInterface,
                 $"The parameter {nameof(capabilityInterface)} must be an interface.");
-            InternalContract.Require(typeof(IControllerInjector).IsAssignableFrom(capabilityInterface), 
+            InternalContract.Require(typeof(IControllerInjector).IsAssignableFrom(capabilityInterface),
                 $"The parameter {nameof(capabilityInterface)} must inherit from {typeof(IControllerInjector).FullName}.");
             foreach (var controllerType in controllerTypes)
             {
@@ -236,7 +236,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
             }
         }
 
-        #region Configure Services
+#region Configure Services
 
         /// <summary>
         /// Makes the initial most urgent Nexus settings - application properties and logging.
@@ -266,22 +266,34 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
         {
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc(ApiVersion, new Info {Title = FulcrumApplication.Setup.Name, Version = ApiVersion});
+                c.SwaggerDoc(ApiVersion, new OpenApiInfo { Title = FulcrumApplication.Setup.Name, Version = ApiVersion });
                 var commentsFilePath = GetCommentsFilePath();
                 if (commentsFilePath != null) c.IncludeXmlComments(commentsFilePath);
                 if (FulcrumApplication.IsInDevelopment) return;
                 c.AddSecurityDefinition("Bearer",
-                    new ApiKeyScheme
+                    new OpenApiSecurityScheme
                     {
-                        In = "header",
+                        In = ParameterLocation.Header,
                         Description = "Please enter into field the word 'Bearer' following by space and JWT",
                         Name = "Authorization",
-                        Type = "apiKey"
+                        Type = SecuritySchemeType.ApiKey
                     });
-                c.AddSecurityRequirement(new Dictionary<string, IEnumerable<string>>
+                // https://stackoverflow.com/questions/56234504/bearer-authentication-in-swagger-ui-when-migrating-to-swashbuckle-aspnetcore-ve
+                var securityRequirement = new OpenApiSecurityRequirement();
+                var securityScheme = new OpenApiSecurityScheme
                 {
-                    {"Bearer", Enumerable.Empty<string>()},
-                });
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    },
+                    Scheme = "oauth2",
+                    Name = "Bearer",
+                    In = ParameterLocation.Header,
+
+                };
+                securityRequirement.Add(securityScheme, new List<string>());
+                c.AddSecurityRequirement(securityRequirement);
             });
         }
 
@@ -340,10 +352,10 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
 
         }
 
-        #endregion
+#endregion
 
 
-        #region Configure
+#region Configure
 
         /// <summary>
         /// Configure the Nexus Link middleware 
@@ -364,7 +376,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
             // Start and stop a batch of logs, see also Nexus.Link.Libraries.Core.Logging.BatchLogger.
             options.Features.BatchLog.Enabled = true;
             // Log all requests and responses
-            options.Features.LogRequestAndResponse.Enabled= true;
+            options.Features.LogRequestAndResponse.Enabled = true;
             // Convert exceptions into error responses (HTTP status codes 400 and 500)
             options.Features.ConvertExceptionToHttpResponse.Enabled = true;
             app.UseNexusLinkMiddleware(options);
@@ -386,7 +398,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Startup
             });
         }
 
-        #endregion
+#endregion
 
         /// <inheritdoc />
         public virtual void Validate(string errorLocation, string propertyPath = "")

--- a/src/Libraries.Web/Libraries.Web.csproj
+++ b/src/Libraries.Web/Libraries.Web.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.20" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />

--- a/src/Libraries.Web/Libraries.Web.csproj
+++ b/src/Libraries.Web/Libraries.Web.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.20" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Libraries.Web/Libraries.Web.csproj
+++ b/src/Libraries.Web/Libraries.Web.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.Libraries.Web</PackageId>
-    <Version>5.33.0</Version>
+    <Version>5.33.1</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -42,6 +42,7 @@
     <Copyright>Copyright ©2021 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      5.33.1 Bump
       5.33.0 ThrowFulcrumExceptionOnFail now can throw FulcrumHttpRedirectException. HttpSender now can throw FulcrumRedirectException
       5.32.0 We were checking for unsuccessful HTTP response too far down in HttpSender
       5.31.4 If there is a custom Accept header, we no longer add "application/json"

--- a/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Storage.Test/Libraries.Azure.Storage.Test.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
@@ -26,10 +26,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -10,10 +10,10 @@
     <RootNamespace>Nexus.Link.Libraries.Web.AspNet.Tests</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Owin" Version="4.2.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,9 +29,9 @@
     <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.32" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">

--- a/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Azure.Web.AspNet.Tests/Libraries.Azure.Web.AspNet.Tests.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Core.Tests/Libraries.Core.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Core.Tests/Libraries.Core.Tests.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Core.Tests/Libraries.Core.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Core.Tests/Libraries.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Nexus.Link.Libraries.Core.Tests</RootNamespace>
     <AssemblyName>Nexus.Link.Libraries.Core.Tests</AssemblyName>
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Core.Tests/Logging/LoggableExtensionsTests.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Logging/LoggableExtensionsTests.cs
@@ -35,7 +35,11 @@ namespace Nexus.Link.Libraries.Core.Tests.Logging
         [DataRow(0, 0, 0, 1, 995, "2.0s")]
         [DataRow(0, 0, 0, 2, 0, "2.0s")]
         [DataRow(0, 0, 0, 9, 949, "9.9s")]
+#if NETCOREAPP
         [DataRow(0, 0, 0, 9, 950, "9.9s")]
+#else
+        [DataRow(0, 0, 0, 9, 950, "10.0s")]
+#endif
         [DataRow(0, 0, 0, 9, 951, "9.5s")] // This does not feel right
         [DataRow(0, 0, 0, 10, 0, "10.0s")]
         [DataRow(0, 0, 0, 29, 999, "29.5s")]

--- a/test/Nexus.Link.Libraries.Core.Tests/Logging/LoggableExtensionsTests.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Logging/LoggableExtensionsTests.cs
@@ -35,7 +35,8 @@ namespace Nexus.Link.Libraries.Core.Tests.Logging
         [DataRow(0, 0, 0, 1, 995, "2.0s")]
         [DataRow(0, 0, 0, 2, 0, "2.0s")]
         [DataRow(0, 0, 0, 9, 949, "9.9s")]
-        [DataRow(0, 0, 0, 9, 950, "10.0s")]
+        [DataRow(0, 0, 0, 9, 950, "9.9s")]
+        [DataRow(0, 0, 0, 9, 951, "9.5s")] // This does not feel right
         [DataRow(0, 0, 0, 10, 0, "10.0s")]
         [DataRow(0, 0, 0, 29, 999, "29.5s")]
         [DataRow(0, 0, 0, 30, 000, "30s")]

--- a/test/Nexus.Link.Libraries.Core.Tests/Threads/TestThreadHelper.cs
+++ b/test/Nexus.Link.Libraries.Core.Tests/Threads/TestThreadHelper.cs
@@ -191,6 +191,12 @@ namespace Nexus.Link.Libraries.Core.Tests.Threads
             UT.Assert.IsTrue(_done);
         }
 
+        [TestMethod]
+        public async Task Delay()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
         private async Task SleepAsync(TimeSpan delay)
         {
             await Task.Delay(delay);

--- a/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
+++ b/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Nexus.Link.Libraries.Crud.Test</RootNamespace>
     <AssemblyName>Nexus.Link.Libraries.Crud.Test</AssemblyName>
@@ -15,19 +15,19 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
+++ b/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
+++ b/test/Nexus.Link.Libraries.Crud.Test/Libraries.Crud.Test.csproj
@@ -7,21 +7,14 @@
     <AssemblyName>Nexus.Link.Libraries.Crud.Test</AssemblyName>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
+  <PropertyGroup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+  <!--<PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
@@ -29,6 +22,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nexus.Link.Libraries.Crud.Test/Model/PageEnvelopeTest.cs
+++ b/test/Nexus.Link.Libraries.Crud.Test/Model/PageEnvelopeTest.cs
@@ -33,7 +33,7 @@ namespace Nexus.Link.Libraries.Crud.Test.Model
 
         public void TestIsWildCard(string searchFor, bool expectedIsWildCard)
         {
-            var (isWildCard, replaced) = SearchDetails<string>.ReplaceWildCard(searchFor);
+            var isWildCard = SearchDetails<string>.ReplaceWildCard(searchFor).Item1;
             Assert.AreEqual(expectedIsWildCard, isWildCard);
         }
 

--- a/test/Nexus.Link.Libraries.Crud.Web.Test/Libraries.Crud.Web.Test.csproj
+++ b/test/Nexus.Link.Libraries.Crud.Web.Test/Libraries.Crud.Web.Test.csproj
@@ -25,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
 
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/test/Nexus.Link.Libraries.Crud.Web.Test/Libraries.Crud.Web.Test.csproj
+++ b/test/Nexus.Link.Libraries.Crud.Web.Test/Libraries.Crud.Web.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Nexus.Link.Libraries.Crud.Web.Test</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -24,9 +24,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
 
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/test/Nexus.Link.Libraries.SqlServer.Test/Libraries.SqlServer.Test.csproj
+++ b/test/Nexus.Link.Libraries.SqlServer.Test/Libraries.SqlServer.Test.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.SqlServer.Test/Libraries.SqlServer.Test.csproj
+++ b/test/Nexus.Link.Libraries.SqlServer.Test/Libraries.SqlServer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -12,10 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/InboundPipeTests.cs
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/InboundPipeTests.cs
@@ -13,7 +13,6 @@ using Nexus.Link.Libraries.Core.Platform.Configurations;
 using Nexus.Link.Libraries.Web.AspNet.Pipe.Inbound;
 #if NETCOREAPP
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -225,7 +224,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Tests.InboundPipe
 #if NETCOREAPP
         private void SetRequest(HttpContext context, string url)
         {
-            var request = new DefaultHttpRequest(context);
+            var request = context.Request;
             var match = Regex.Match(url, "^(https?)://([^/]+)(/[^?]+)(\\?.*)?$");
             request.Scheme = match.Groups[1].Value;
             request.Host = new HostString(match.Groups[2].Value);

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/LogRequestResponseTests.cs
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/LogRequestResponseTests.cs
@@ -10,7 +10,6 @@ using Nexus.Link.Libraries.Web.AspNet.Pipe.Inbound;
 using Nexus.Link.Libraries.Web.Error.Logic;
 #if NETCOREAPP
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using System.IO;
 using System.Text.RegularExpressions;
 #pragma warning disable 618
@@ -292,7 +291,7 @@ namespace Nexus.Link.Libraries.Web.AspNet.Tests.InboundPipe
 #if NETCOREAPP
         private void SetRequest(HttpContext context, string url)
         {
-            var request = new DefaultHttpRequest(context);
+            var request = context.Request;
             var match = Regex.Match(url, "^(https?)://([^/]+)(/[^?]+)(\\?.*)?$");
             request.Scheme = match.Groups[1].Value;
             request.Host = new HostString(match.Groups[2].Value);

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/NexusLinkMiddleware/Support.cs
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/NexusLinkMiddleware/Support.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Nexus.Link.Libraries.Web.Pipe;
 using Newtonsoft.Json.Linq;
 #pragma warning disable CS0618
@@ -22,17 +21,15 @@ namespace Nexus.Link.Libraries.Web.AspNet.Tests.InboundPipe.NexusLinkMiddleware
             }
             var memoryStream = jObject == null ? new MemoryStream() : new MemoryStream(Encoding.UTF8.GetBytes(jObject.ToString()));
 
-            var request = new DefaultHttpRequest(context)
-            {
-                Scheme = match.Groups[1].Value,
-                Host = new HostString(match.Groups[2].Value),
-                PathBase = new PathString("/"),
-                Path = new PathString(match.Groups[3].Value),
-                Method = method,
-                Body = memoryStream,
-                ContentLength = memoryStream.Length,
-                QueryString = new QueryString(match.Groups[4].Value)
-            };
+            var request = context.Request;
+            request.Scheme = match.Groups[1].Value;
+            request.Host = new HostString(match.Groups[2].Value);
+            request.PathBase = new PathString("/");
+            request.Path = new PathString(match.Groups[3].Value);
+            request.Method = method;
+            request.Body = memoryStream;
+            request.ContentLength = memoryStream.Length;
+            request.QueryString = new QueryString(match.Groups[4].Value);
             return request;
         }
 
@@ -44,17 +41,15 @@ namespace Nexus.Link.Libraries.Web.AspNet.Tests.InboundPipe.NexusLinkMiddleware
         public static HttpRequest SetRequestWithReentryAuthentication(this DefaultHttpContext context, string reentryAuthentication)
         {
             var memoryStream = new MemoryStream();
-            var request = new DefaultHttpRequest(context)
-            {
-                Scheme = "https",
-                Host = new HostString("host.example.com"),
-                PathBase = new PathString("/"),
-                Path = new PathString("/Person/123"),
-                Method = "Get",
-                Body = memoryStream,
-                ContentLength = memoryStream.Length,
-                QueryString = new QueryString("?id=23")
-            };
+            var request = context.Request;
+            request.Scheme = "https";
+            request.Host = new HostString("host.example.com");
+            request.PathBase = new PathString("/");
+            request.Path = new PathString("/Person/123");
+            request.Method = "Get";
+            request.Body = memoryStream;
+            request.ContentLength = memoryStream.Length;
+            request.QueryString = new QueryString("?id=23");
             if (reentryAuthentication != null)
             {
                 request.Headers.Add(Constants.ReentryAuthenticationHeaderName, reentryAuthentication);

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/Support/TestStartup.cs
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/InboundPipe/Support/TestStartup.cs
@@ -29,7 +29,11 @@ namespace Nexus.Link.Libraries.Web.AspNet.Tests.InboundPipe.Support
         public virtual void ConfigureServices(IServiceCollection services)
         {
             var valueTranslatorFilter = new ValueTranslatorFilter(TranslatorService, GetTranslatorClientName);
-            var mvc = services.AddMvc(opts => { opts.Filters.Add(valueTranslatorFilter); });
+            var mvc = services.AddMvc(opts =>
+            {
+                opts.Filters.Add(valueTranslatorFilter);
+                opts.EnableEndpointRouting = false;
+            });
             mvc.SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
@@ -27,10 +27,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.32" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.2.0, 3.0)" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>

--- a/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.AspNet.Tests/Libraries.Web.AspNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -10,11 +10,11 @@
     <RootNamespace>Nexus.Link.Libraries.Web.AspNet.Tests</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1, 3.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.2.0, 3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Owin" Version="4.2.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,9 +30,9 @@
     <PackageReference Include="Microsoft.Owin" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>

--- a/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
@@ -35,4 +35,10 @@
     <Folder Include="Clients\" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing">
+      <Version>3.1.32</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 

--- a/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
+++ b/test/Nexus.Link.Libraries.Web.Tests/Libraries.Web.Tests.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
There are a number of our libraries that are dependent on public NuGets where the old versions (that we are using) have known security risks. Visual studio complains about these.

I have updated all those nuget packages and bumped all our nugt packages.

One effect of this was that I had to move from netcoreapp2.1 to netcoreapp3.1 for all AspNet libraries. Is that OK?
